### PR TITLE
Use meson's debug option to detect development versions

### DIFF
--- a/script/meson-aux-cargo
+++ b/script/meson-aux-cargo
@@ -5,11 +5,11 @@ export MESON_SOURCE_ROOT="$2"
 export CARGO_TARGET_DIR="$MESON_BUILD_ROOT"/target
 export CARGO_HOME="$CARGO_TARGET_DIR"/cargo-home
 export OUTPUT="$3"
-export BUILDTYPE="$4"
+export DEBUG="$4"
 export APP_BIN="$5"
 
 
-if [[ $BUILDTYPE = "release" ]]
+if [[ $DEBUG = "False" ]]
 then
     echo "RELEASE MODE"
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,7 @@ cargo_release = custom_target(
     meson.project_build_root(),
     meson.project_source_root(),
     '@OUTPUT@',
-    get_option('buildtype'),
+    get_option('debug'),
     meson.project_name(),
   ]
 )


### PR DESCRIPTION
meson's buildtype option contains not only if the build is not using debug, but also configures the optimization option.

The issue was found in Alpine, where all meson packages are built with 'plain' as buildtype and not 'release', but both options set debug=false.

Ref: https://mesonbuild.com/Builtin-options.html#details-for-buildtype