### PR TITLE
fix database size display for sizes above 1023 KiB

### DIFF
--- a/src/ui/overview.rs
+++ b/src/ui/overview.rs
@@ -131,9 +131,9 @@ fn render_size(bytes: u64) -> String {
     let kib = bytes / 1024;
     if kib < 1024 { return format!("{kib} KiB") }
 
-    let mib = bytes / 1024;
+    let mib = kib / 1024;
     if mib < 1024 { return format!("{mib} MiB") }
 
-    let gib = bytes / 1024;
+    let gib = mib / 1024;
     format!("{gib} GiB")
 }


### PR DESCRIPTION
I noticed that Tangara Companion was reporting my database size as several TiB, which seemed farfetched given my Tangara only has a 512GB SD card 😅

Was a fairly simple fix, in the end!