### PR TITLE
update espflash to 4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "espflash"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae69927fa129d5bf119dc39fe984de95851f7ef918d06d14df95f8a74c59cda"
+checksum = "0c63d954132db04edb660af5a554a46f909f7b172d7601b4af3fea994b926821"
 dependencies = [
  "base64",
  "bitflags 2.9.4",
@@ -603,6 +603,7 @@ dependencies = [
  "log",
  "md-5",
  "miette",
+ "nix 0.30.1",
  "object 0.37.3",
  "regex",
  "serde",
@@ -611,7 +612,7 @@ dependencies = [
  "slip-codec",
  "strum",
  "thiserror 2.0.16",
- "toml",
+ "toml 0.9.6",
 ]
 
 [[package]]
@@ -1665,6 +1666,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no_std_io2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,7 +2430,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml",
+ "toml 0.8.23",
  "version-compare",
 ]
 
@@ -2648,9 +2670,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.1",
+ "toml_datetime 0.7.1",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -2679,9 +2716,8 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_write",
  "winnow",
 ]
 
@@ -2707,10 +2743,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"

--- a/crates/tangara-lib/Cargo.toml
+++ b/crates/tangara-lib/Cargo.toml
@@ -16,5 +16,5 @@ thiserror = { workspace = true }
 
 # general deps
 crc32fast = "1.4.2"
-espflash = { version = "4.0", default-features = false, features = [ "serialport" ] }
+espflash = { version = "4.1", default-features = false, features = [ "serialport" ] }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/crates/tangara-lib/src/firmware.rs
+++ b/crates/tangara-lib/src/firmware.rs
@@ -166,14 +166,6 @@ fn read_image_data(zip: &mut ZipArchive<File>, name: &str)
     let crc32 = file.crc32();
     let expected_crc32 = crc32fast::hash(&data);
 
-    // If the file size is not divisible by 4, we need to pad `FF` bytes to the end
-    // This should be removed when https://github.com/esp-rs/espflash/pull/951 is merged and released upstream.
-    let mut padded_bytes = 0;
-    if size % 4 != 0 {
-        padded_bytes = 4 - (size % 4);
-    }
-    data.extend(std::iter::repeat_n(0xFF, padded_bytes));
-
     if crc32 != expected_crc32 {
         Err(ReadImageError::BadCRC(crc32, expected_crc32))
     } else {


### PR DESCRIPTION
to remove workaround padding images to 4 bytes