### PR TITLE
Bump Gnome platform version in Flatpak build

### DIFF
--- a/pkg/flatpak/zone.cooltech.tangara.Companion.yml
+++ b/pkg/flatpak/zone.cooltech.tangara.Companion.yml
@@ -1,7 +1,7 @@
 id: zone.cooltech.tangara.Companion
 branch: stable
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
The flatpak installer kept giving me deprecation warnings about Freedesktop and Gnome platform dependencies being end-of-life, bumping Gnome platform in Flatpak build of Tangara Companion from 47 to 49 seems to make the warnings go away. Everything still builds and works as expected :)